### PR TITLE
Added Max overrides counter per day

### DIFF
--- a/background.js
+++ b/background.js
@@ -270,7 +270,7 @@ function checkReset() {
 				timeLeft = data.timeLimit*60;
 
 				// reset number of available overrides for today
-				chrome.storage.local.get({"overrideLimit":10}, function(data) {
+				chrome.storage.local.get({"overrideLimit":5}, function(data) {
 					chrome.storage.local.set({"currentOverrideCount": data.overrideLimit});
 				});
 

--- a/background.js
+++ b/background.js
@@ -269,6 +269,11 @@ function checkReset() {
 				override = false;
 				timeLeft = data.timeLimit*60;
 
+				// reset number of available overrides for today
+				chrome.storage.local.get({"overrideCount":1}, function(data) {
+					chrome.storage.local.set({"currentOverrideCount": data.overrideCount});
+				});
+
 			});
 
 		} else {

--- a/background.js
+++ b/background.js
@@ -270,8 +270,8 @@ function checkReset() {
 				timeLeft = data.timeLimit*60;
 
 				// reset number of available overrides for today
-				chrome.storage.local.get({"overrideCount":1}, function(data) {
-					chrome.storage.local.set({"currentOverrideCount": data.overrideCount});
+				chrome.storage.local.get({"overrideLimit":10}, function(data) {
+					chrome.storage.local.set({"currentOverrideCount": data.overrideLimit});
 				});
 
 			});

--- a/css/options.css
+++ b/css/options.css
@@ -9,7 +9,7 @@
 	margin-right: 7px;
 }
 
-#overrideCount {
+#overrideLimit {
 	width: 100px;
 	margin-right: 7px;
 }
@@ -19,7 +19,7 @@
 	margin-right: 7px;
 }
 
-#minuterow {
+#minuterow, #overrideLimitRow {
 	width: max-content;
 	margin: auto;
 }

--- a/css/options.css
+++ b/css/options.css
@@ -9,6 +9,11 @@
 	margin-right: 7px;
 }
 
+#overrideCount {
+	width: 100px;
+	margin-right: 7px;
+}
+
 #time {
 	width: 130px;
 	margin-right: 7px;

--- a/js/blocked.js
+++ b/js/blocked.js
@@ -11,37 +11,38 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 $("#override").click(function() {
 	var answer = confirm("Are you sure you need to use YouTube?")
 	if (answer) {
-    ga('send', {hitType: 'event', eventCategory: 'Blocked page', eventAction: 'Override'});
+    	ga('send', {hitType: 'event', eventCategory: 'Blocked page', eventAction: 'Override'});
 		// update currentOverrideCount
-		chrome.storage.local.get({"currentOverrideCount":-1}, function(data) {
-			chrome.storage.local.set({"currentOverrideCount": data.currentOverrideCount - 1}, function()
-			{
-				alert(data.currentOverrideCount--);
-
+		chrome.storage.local.get({"currentOverrideCount":1, "limitOverrides":true}, function(data) {
+			if (data.limitOverrides) {
+				chrome.storage.local.set({"currentOverrideCount": data.currentOverrideCount - 1}, function() {
+					chrome.runtime.sendMessage({
+						msg: "override", 
+						value: true
+					});
+				});
+			} else {
 				chrome.runtime.sendMessage({
 					msg: "override", 
 					value: true
 				});
-			});
+			}
 		});
 		
 	}
 });
 
-// check if we still have some overrides left, otherwise hide the div with the button
-chrome.storage.local.get({"currentOverrideCount":-1}, function(data) {
+// check if we still have some overrides left, otherwise remove the div with the button
+chrome.storage.local.get({"currentOverrideCount":0, "limitOverrides":true}, function(data) {
 
-	if(data.currentOverrideCount < 1)
-	{
-		// hide the button
-		$("#overrideCommands").hide();
+	if(data.currentOverrideCount < 1 && data.limitOverrides) {
+		// delete the button
+		$("#overrideCommands").remove();
+	} else {
+		if (data.limitOverrides)
+			$("#overridesLeft").text(data.currentOverrideCount + " Left");
+		$("#overrideCommands").show();
 	}
-
-	// clean up if for some reasons currentOverrideCount was not set before
-	if (data.currentOverrideCount == -1)
-		data.currentOverrideCount = 0;
-
-	$("#overrideLeft").text(data.currentOverrideCount + " Left");
 	
 });
 

--- a/js/blocked.js
+++ b/js/blocked.js
@@ -9,11 +9,38 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 $("#override").click(function() {
 	var answer = confirm("Are you sure you need to use YouTube?")
 	if (answer) {
-		chrome.runtime.sendMessage({
-			msg: "override", 
-			value: true
+
+		// update currentOverrideCount
+		chrome.storage.local.get({"currentOverrideCount":-1}, function(data) {
+			chrome.storage.local.set({"currentOverrideCount": data.currentOverrideCount - 1}, function()
+			{
+				alert(data.currentOverrideCount--);
+
+				chrome.runtime.sendMessage({
+					msg: "override", 
+					value: true
+				});
+			});
 		});
+		
 	}
+});
+
+// check if we still have some overrides left, otherwise hide the div with the button
+chrome.storage.local.get({"currentOverrideCount":-1}, function(data) {
+
+	if(data.currentOverrideCount < 1)
+	{
+		// hide the button
+		$("#overrideCommands").hide();
+	}
+
+	// clean up if for some reasons currentOverrideCount was not set before
+	if (data.currentOverrideCount == -1)
+		data.currentOverrideCount = 0;
+
+	$("#overrideLeft").text(data.currentOverrideCount + " Left");
+	
 });
 
 function isYoutubeVideo(url) {

--- a/js/options.js
+++ b/js/options.js
@@ -1,5 +1,12 @@
 ga('send', 'pageview', '/options.html');
 
+chrome.storage.local.get({"limitOverrides":true}, function(data) {
+	if (data.limitOverrides == true) {
+		$('#limitOverrides').prop('checked', true);
+		$('#overrideLimitRow').css("visibility", "visible");
+	}
+});
+
 chrome.storage.local.get({"timeLimit":30}, function(data) {
 	$("#minutes").val(data.timeLimit);
 });
@@ -9,8 +16,9 @@ chrome.storage.local.get({"pauseOutOfFocus":false}, function(data) {
 		$('#pauseOutOfFocus').prop('checked', true);
 });
 
-chrome.storage.local.get({"overrideCount":1}, function(data) {
-	$("#overrideCount").val(data.overrideCount);
+
+chrome.storage.local.get({"overrideLimit":10}, function(data) {
+	$("#overrideLimit").val(data.overrideLimit);
 });
 
 
@@ -41,12 +49,18 @@ $("#saveMinutes").click(function() {
 	});
 });
 
-$("#saveOverrideCount").click(function() {
-	chrome.storage.local.set({"overrideCount": $("#overrideCount").val(), "currentOverrideCount": $("#overrideCount").val()}, function() {
-		chrome.runtime.sendMessage({
-			msg: "overrideCountUpdated"
-		});
-		alert("Max Overrides count Saved");
+$("#saveOverrideLimit").click(function() {
+	let overrideLimit = Number($("#overrideLimit").val());
+	if (overrideLimit < 0) {
+		overrideLimit = 0;
+	} else if (overrideLimit > 1000) {
+		overrideLimit = 1000;
+	}
+	$("#overrideLimit").val(overrideLimit);
+	ga('send', {hitType: 'event', eventCategory: 'Settings', eventAction: 'Updated override limit', eventValue: overrideLimit});
+
+	chrome.storage.local.set({"overrideLimit": overrideLimit, "currentOverrideCount": overrideLimit}, function() {
+		alert("Override Limit Saved");
 	});
 });
 
@@ -73,5 +87,17 @@ $('#pauseOutOfFocus').change(function() {
 		ga('send', {hitType: 'event', eventCategory: 'Settings', eventAction: 'Updated pause out of focus', eventLabel: "false", eventValue: 0});
 		chrome.storage.local.set({"pauseOutOfFocus": false});
 		chrome.runtime.sendMessage({msg: "pauseOutOfFocus", val: false});
+	}
+});
+
+$('#limitOverrides').change(function() {
+	if (this.checked) {
+		$('#overrideLimitRow').css("visibility", "visible");
+		ga('send', {hitType: 'event', eventCategory: 'Settings', eventAction: 'Updated limit overrides toggle', eventLabel: "true", eventValue: 1});
+		chrome.storage.local.set({"limitOverrides": true});
+	} else {
+		$('#overrideLimitRow').css("visibility", "hidden");
+		ga('send', {hitType: 'event', eventCategory: 'Settings', eventAction: 'Updated limit overrides toggle', eventLabel: "false", eventValue: 0});
+		chrome.storage.local.set({"limitOverrides": false});
 	}
 });

--- a/js/options.js
+++ b/js/options.js
@@ -17,7 +17,7 @@ chrome.storage.local.get({"pauseOutOfFocus":false}, function(data) {
 });
 
 
-chrome.storage.local.get({"overrideLimit":10}, function(data) {
+chrome.storage.local.get({"overrideLimit":5}, function(data) {
 	$("#overrideLimit").val(data.overrideLimit);
 });
 

--- a/js/options.js
+++ b/js/options.js
@@ -7,6 +7,10 @@ chrome.storage.local.get({"pauseOutOfFocus":false}, function(data) {
 		$('#pauseOutOfFocus').prop('checked', true);
 });
 
+chrome.storage.local.get({"overrideCount":1}, function(data) {
+	$("#overrideCount").val(data.overrideCount);
+});
+
 
 chrome.storage.local.get({"resetTime":"00:00"}, function(data) {
 	$("#time").val(data.resetTime);
@@ -31,6 +35,15 @@ $("#saveMinutes").click(function() {
 			msg: "timeLimitUpdated"
 		});
 		alert("Limit Saved");
+	});
+});
+
+$("#saveOverrideCount").click(function() {
+	chrome.storage.local.set({"overrideCount": $("#overrideCount").val(), "currentOverrideCount": $("#overrideCount").val()}, function() {
+		chrome.runtime.sendMessage({
+			msg: "overrideCountUpdated"
+		});
+		alert("Max Overrides count Saved");
 	});
 });
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "YouTube Time",
   "description": "Prevent procrastination by setting a daily time limit for your YouTube usage.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "icons":
   {
     "128": "images/icon - 128.png"

--- a/pages/blocked.html
+++ b/pages/blocked.html
@@ -9,7 +9,10 @@
 <body>
 	<div id="container">
 		<h1 id="title">Time is up</h1>
-		<button id="override" class="btn btn-secondary">Override</button>
+		<div id="overrideCommands">
+			<button id="override" class="btn btn-secondary">Override</button>
+			<div id="overrideLeft">Overrides left</label>
+		</div>
 		<script src="../js/blocked.js"></script>
 	</div>
 </body>

--- a/pages/blocked.html
+++ b/pages/blocked.html
@@ -10,9 +10,9 @@
 <body>
 	<div id="container">
 		<h1 id="title">Time is up</h1>
-		<div id="overrideCommands">
+		<div id="overrideCommands" style="display: none;">
 			<button id="override" class="btn btn-secondary">Override</button>
-			<div id="overrideLeft">Overrides left</label>
+			<div id="overridesLeft"></div>
 		</div>
 		<script src="../js/blocked.js"></script>
 	</div>

--- a/pages/options.html
+++ b/pages/options.html
@@ -22,10 +22,13 @@
 			<input type="submit" id="saveTime" value="Save Time" class="btn btn-info">
 		</div>
 
-		<label for="minutes"><h4>How many overrides allowed per day:</h4></label>
-		<div id="minuterow" class="row mb-3">
-			<input id="overrideCount" class="form-control" type="number" min="0" max="1439">
-			<input type="submit" id="saveOverrideCount" value="Save Override Count" class="btn btn-info">
+		<div class="row justify-content-center">
+			<label for="limitOverrides"><h4>Limit the number of overrides allowed per day:</h4></label>
+			<input id="limitOverrides" class="big-checkbox ml-2" type="checkbox">
+		</div>
+		<div id="overrideLimitRow" class="row mb-3" style="visibility: hidden;">
+			<input id="overrideLimit" class="form-control" type="number" min="0" max="1000">
+			<input type="submit" id="saveOverrideLimit" value="Save Override Limit" class="btn btn-info">
 		</div>
 
 		<div class="row justify-content-center">

--- a/pages/options.html
+++ b/pages/options.html
@@ -21,6 +21,12 @@
 			<input type="submit" id="saveTime" value="Save Time" class="btn btn-info">
 		</div>
 
+		<label for="minutes"><h4>How many overrides allowed per day:</h4></label>
+		<div id="minuterow" class="row mb-3">
+			<input id="overrideCount" class="form-control" type="number" min="0" max="1439">
+			<input type="submit" id="saveOverrideCount" value="Save Override Count" class="btn btn-info">
+		</div>
+
 		<div class="row justify-content-center">
 			<label for="pauseOutOfFocus"><h4>Pause timer when YouTube is minimized/out of focus: </h4></label>
 			<input id="pauseOutOfFocus" class="big-checkbox ml-2" type="checkbox">


### PR DESCRIPTION
- The counter will reset every day to the number of overrides set in the options
- it will reset if the user will set that field again in the options
- on blocked, if the currentCounter is 0, it will just hide the override button in the HTML page.

Suggestion for improvements:

- protect the options page with a password;
- not simply hide the button but completely remove the node from the page